### PR TITLE
Fix for german nationality on ID-Cards and passports

### DIFF
--- a/MRZCodeParser/CodeTypes/TD1FirstLine.cs
+++ b/MRZCodeParser/CodeTypes/TD1FirstLine.cs
@@ -8,7 +8,7 @@ namespace MRZCodeParser.CodeTypes
         {
         }
 
-        protected override string Pattern => "([A|C|I][A-Z0-9<]{1})([A-Z]{3})([A-Z0-9<]{9})([0-9]{1})([A-Z0-9<]{15})";
+        protected override string Pattern => "([A|C|I][A-Z0-9<]{1})([A-Z<]{3})([A-Z0-9<]{9})([0-9]{1})([A-Z0-9<]{15})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {

--- a/MRZCodeParser/CodeTypes/TD1SecondLine.cs
+++ b/MRZCodeParser/CodeTypes/TD1SecondLine.cs
@@ -9,7 +9,7 @@ namespace MRZCodeParser.CodeTypes
         }
 
         protected override string Pattern =>
-            "([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z]{3})([A-Z0-9<]{11})([0-9]{1})";
+            "([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z<]{3})([A-Z0-9<]{11})([0-9]{1})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {

--- a/MRZCodeParser/CodeTypes/TD2FirstLine.cs
+++ b/MRZCodeParser/CodeTypes/TD2FirstLine.cs
@@ -8,7 +8,7 @@ namespace MRZCodeParser.CodeTypes
         {
         }
 
-        protected override string Pattern => "([A|C|I][A-Z0-9<]{1})([A-Z]{3})([A-Z0-9<]{31})";
+        protected override string Pattern => "([A|C|I][A-Z0-9<]{1})([A-Z<]{3})([A-Z0-9<]{31})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {

--- a/MRZCodeParser/CodeTypes/TD2SecondLine.cs
+++ b/MRZCodeParser/CodeTypes/TD2SecondLine.cs
@@ -9,7 +9,7 @@ namespace MRZCodeParser.CodeTypes
         }
 
         protected override string Pattern =>
-            "([A-Z0-9<]{9})([0-9]{1})([A-Z]{3})([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z0-9<]{7})([0-9]{1})";
+            "([A-Z0-9<]{9})([0-9]{1})([A-Z<]{3})([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z0-9<]{7})([0-9]{1})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {

--- a/MRZCodeParser/CodeTypes/TD3FirstLine.cs
+++ b/MRZCodeParser/CodeTypes/TD3FirstLine.cs
@@ -8,7 +8,7 @@ namespace MRZCodeParser.CodeTypes
         {
         }
 
-        protected override string Pattern => "(P[A-Z0-9<]{1})([A-Z]{3})([A-Z0-9<]{39})";
+        protected override string Pattern => "(P[A-Z0-9<]{1})([A-Z<]{3})([A-Z0-9<]{39})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {

--- a/MRZCodeParser/CodeTypes/TD3SecondLine.cs
+++ b/MRZCodeParser/CodeTypes/TD3SecondLine.cs
@@ -9,7 +9,7 @@ namespace MRZCodeParser.CodeTypes
         }
 
         protected override string Pattern =>
-            "([A-Z0-9<]{9})([0-9]{1})([A-Z]{3})([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z0-9<]{14})([0-9]{1})([0-9]{1})";
+            "([A-Z0-9<]{9})([0-9]{1})([A-Z<]{3})([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z0-9<]{14})([0-9<]{1})([0-9]{1})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {


### PR DESCRIPTION
Germany uses just a 1 character nationality (D) and not 3 characters as the most other countries. That's why the parser wasn't working before.
The implementation didn't follow the correct format as well: https://en.wikipedia.org/wiki/Machine-readable_passport#Format

Here you can see that nationality can include "<" as character and the optional data check digit on TD3 can be < as well.

This fixes #1 