### PR TITLE
Support of ID cards with no expiration date!

### DIFF
--- a/MRZCodeParser/CodeTypes/TD1SecondLine.cs
+++ b/MRZCodeParser/CodeTypes/TD1SecondLine.cs
@@ -9,7 +9,7 @@ namespace MRZCodeParser.CodeTypes
         }
 
         protected override string Pattern =>
-            "([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9]{6})([0-9]{1})([A-Z<]{3})([A-Z0-9<]{11})([0-9]{1})";
+            "([0-9]{6})([0-9]{1})([M|F|X|<]{1})([0-9<]{6})([0-9]{1})([A-Z<]{3})([A-Z0-9<]{11})([0-9]{1})";
 
         internal override IEnumerable<FieldType> FieldTypes => new[]
         {


### PR DESCRIPTION
MD ID cards has valid cases when there is no expiration date for senior age! 
As result the T1 MRZ types expiration date section is <<<<<<0