### PR TITLE
Adding support for belgium id cards, Update to .net9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 bin/
 *.DotSettings.user
 dist/
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 *.DotSettings.user
 dist/
 /.vs
+/MRZCodeParser.Tests/TD1DocumentLongMrzCodeTest - Copy.cs

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ bin/
 *.DotSettings.user
 dist/
 /.vs
-/MRZCodeParser.Tests/TD1DocumentLongMrzCodeTest - Copy.cs

--- a/MRZCode.Samples/MRZCode.Samples.csproj
+++ b/MRZCode.Samples/MRZCode.Samples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MRZCode.Samples/MRZCode.Samples.csproj
+++ b/MRZCode.Samples/MRZCode.Samples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>netstandard2.1;net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MRZCode.Samples/TD1_doc_longSample.cs
+++ b/MRZCode.Samples/TD1_doc_longSample.cs
@@ -1,0 +1,41 @@
+using System;
+using MRZCodeParser;
+
+namespace MRZCode.Samples
+{
+    public static class TD1_doc_long_Sample
+    {
+        public static void Run()
+        {
+            var text = @"IDBEL123456789<2383<<<<<<<<<<<
+7408122F1204159BEL740812123457
+ERIKSSON<<ANNA<MARIA<<<<<<<<<<";
+
+            Console.WriteLine("TD1 long document id code sample");
+            Console.WriteLine();
+            Console.WriteLine(text);
+            Console.WriteLine();
+
+            var mrzCode = MrzCode.Parse(text);
+
+            Console.WriteLine("Code type:                {0}", mrzCode.Type);
+
+            Console.WriteLine("DocumentType:             {0}", mrzCode[FieldType.DocumentType]);
+            Console.WriteLine("CountryCode:              {0}", mrzCode[FieldType.CountryCode]);
+            Console.WriteLine("DocumentNumber:           {0}", mrzCode[FieldType.DocumentNumber]);
+            Console.WriteLine("DocumentNumberCheckDigit: {0}", mrzCode[FieldType.DocumentNumberCheckDigit]);
+            Console.WriteLine("OptionalData1:            {0}", mrzCode[FieldType.OptionalData1]);
+            Console.WriteLine("BirthDate:                {0}", mrzCode[FieldType.BirthDate]);
+            Console.WriteLine("BirthDateCheckDigit:      {0}", mrzCode[FieldType.BirthDateCheckDigit]);
+            Console.WriteLine("Sex:                      {0}", mrzCode[FieldType.Sex]);
+            Console.WriteLine("ExpiryDate:               {0}", mrzCode[FieldType.ExpiryDate]);
+            Console.WriteLine("ExpiryDateCheckDigit:     {0}", mrzCode[FieldType.ExpiryDateCheckDigit]);
+            Console.WriteLine("Nationality:              {0}", mrzCode[FieldType.Nationality]);
+            Console.WriteLine("OptionalData2:            {0}", mrzCode[FieldType.OptionalData2]);
+            Console.WriteLine("OverallCheckDigit:        {0}", mrzCode[FieldType.OverallCheckDigit]);
+            Console.WriteLine("Names:                    {0}", mrzCode[FieldType.Names]);
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
+++ b/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
+++ b/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>netstandard2.1;net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
+++ b/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
@@ -7,6 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <Compile Remove="TD1DocumentLongMrzCodeTest - Copy.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
+++ b/MRZCodeParser.Tests/MRZCodeParser.Tests.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>netstandard2.1;net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
-
-    <ItemGroup>
-      <Compile Remove="TD1DocumentLongMrzCodeTest - Copy.cs" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/MRZCodeParser.Tests/MrzSamples.cs
+++ b/MRZCodeParser.Tests/MrzSamples.cs
@@ -14,6 +14,10 @@ ERIKSSON<<ANNA<MARIA<<<<<<<<<<";
 7408122F1204159D<<<<<<<<<<<<<6
 ERIKSSON<<ANNA<MARIA<<<<<<<<<<";
 
+        public const string TD1_LONGER_DOCUMENT_ID = @"IDBEL111111111<5227<<<<<<<<<<<
+7408122F2912207BEL110801555552
+ERIKSSON<<ANNA<MARIA<<<<<<<<<<";
+
         public const string TD2 = @"I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<
 D231458907UTO7408122F1204159<<<<<<<6";
 

--- a/MRZCodeParser.Tests/TD1DocumentLongMrzCodeTest.cs
+++ b/MRZCodeParser.Tests/TD1DocumentLongMrzCodeTest.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MRZCodeParser.Tests
+{
+    public class TD1DocumentLongMrzCodeTest
+    {
+        [Fact]
+        public void CodeFieldsTest()
+        {
+            var target = MrzCode.Parse(MrzSamples.TD1_LONGER_DOCUMENT_ID);
+
+            Assert.Equal(DocumentType.ID.ToString(), target[FieldType.DocumentType]);
+            Assert.Equal("BEL", target[FieldType.CountryCode]);
+            Assert.Equal("111111111522", target[FieldType.DocumentNumber]);
+            Assert.Equal("7", target[FieldType.DocumentNumberCheckDigit]);
+            Assert.Equal("", target[FieldType.OptionalData1]);
+            Assert.Equal("740812", target[FieldType.BirthDate]);
+            Assert.Equal("2", target[FieldType.BirthDateCheckDigit]);
+            Assert.Equal("F", target[FieldType.Sex]);
+            Assert.Equal("291220", target[FieldType.ExpiryDate]);
+            Assert.Equal("7", target[FieldType.ExpiryDateCheckDigit]);
+            Assert.Equal("BEL", target[FieldType.Nationality]);
+            Assert.Equal("11080155555", target[FieldType.OptionalData2]);
+            Assert.Equal("2", target[FieldType.OverallCheckDigit]);
+            Assert.Equal("ERIKSSON, ANNA MARIA", target[FieldType.Names]);
+        }
+
+
+        [Fact]
+        public void FieldTypeCollectionTest()
+        {
+            var target = MrzCode.Parse(MrzSamples.TD1);
+
+            var expected = new[]
+            {
+                FieldType.DocumentType,
+                FieldType.CountryCode,
+                FieldType.DocumentNumber,
+                FieldType.DocumentNumberCheckDigit,
+                FieldType.OptionalData1,
+                FieldType.BirthDate,
+                FieldType.BirthDateCheckDigit,
+                FieldType.Sex,
+                FieldType.ExpiryDate,
+                FieldType.ExpiryDateCheckDigit,
+                FieldType.Nationality,
+                FieldType.OptionalData2,
+                FieldType.OverallCheckDigit,
+                FieldType.Names
+            };
+
+            var actual = target.FieldTypes.ToList();
+
+            Assert.Equal(expected.Length, actual.Count());
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/MRZCodeParser.Tests/TD1MrzCodeLinesTest.cs
+++ b/MRZCodeParser.Tests/TD1MrzCodeLinesTest.cs
@@ -16,7 +16,7 @@ namespace MRZCodeParser.Tests
             Assert.Equal("7", target.Fields[FieldType.DocumentNumberCheckDigit].Value);
             Assert.Equal("", target.Fields[FieldType.OptionalData1].Value);
         }
-        
+
         [Fact]
         public void SecondLineFieldsTest()
         {

--- a/MRZCodeParser/CodeType.cs
+++ b/MRZCodeParser/CodeType.cs
@@ -7,6 +7,7 @@ namespace MRZCodeParser
         TD2,
         TD3,
         MRVA,
-        MRVB
+        MRVB,
+        TD1_LONG_DOC_NUMBER
     }
 }

--- a/MRZCodeParser/CodeTypeDetector.cs
+++ b/MRZCodeParser/CodeTypeDetector.cs
@@ -7,6 +7,11 @@ namespace MRZCodeParser
     {
         private readonly IEnumerable<string> lines;
 
+        /// <summary>
+        /// Countries that use TD1 with long document number (30 characters).
+        /// </summary>
+        private readonly IEnumerable<string> Countries_LongDocNumber = new List<string> { "BEL" };
+
         internal CodeTypeDetector(IEnumerable<string> lines)
         {
             this.lines = lines;
@@ -15,7 +20,8 @@ namespace MRZCodeParser
         internal CodeType DetectType()
         {
             CodeType type = lines.Count() == 3 && lines.First().Length == 30
-                ? CodeType.TD1
+                ? Countries_LongDocNumber.Contains(lines.First().Substring(2,3)) 
+                ? CodeType.TD1_LONG_DOC_NUMBER : CodeType.TD1
                 : lines.First().Length == 44 && lines.Count() == 2
                     ? lines.First()[0] == 'P'
                         ? CodeType.TD3

--- a/MRZCodeParser/CodeTypes/TD1FirstLineLongDocument.cs
+++ b/MRZCodeParser/CodeTypes/TD1FirstLineLongDocument.cs
@@ -2,12 +2,12 @@ using System.Collections.Generic;
 
 namespace MRZCodeParser.CodeTypes
 {
-    internal class TD1FirstLine : MrzLine
+    internal class TD1FirstLineLongDocument : MrzLine
     {
-        internal TD1FirstLine(string value) : base(value)
+        internal TD1FirstLineLongDocument(string value) : base(value)
         { }
 
-        protected override string Pattern => "([A|C|I][A-Z0-9<]{1})([A-Z<]{3})([A-Z0-9<]{9})([0-9]{1})([A-Z0-9<]{15})";
+        protected override string Pattern => "([A|C|I][A-Z0-9<]{1})([A-Z<]{3})([A-Z0-9<]{13})([0-9]{1})([A-Z0-9<]{11})";
 
 
         internal override IEnumerable<FieldType> FieldTypes => new[]

--- a/MRZCodeParser/CodeTypes/TD1LongDocumentMrzCode.cs
+++ b/MRZCodeParser/CodeTypes/TD1LongDocumentMrzCode.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MRZCodeParser.CodeTypes
+{
+    internal class TD1LongDocumentMrzCode : MrzCode
+    {
+        internal TD1LongDocumentMrzCode(IEnumerable<string> lines) : base(lines)
+        {
+        }
+
+        public override CodeType Type => CodeType.TD1;
+
+        public override IEnumerable<MrzLine> Lines => new MrzLine[]
+        {
+            new TD1FirstLineLongDocument(RawLines.First()),
+            new TD1SecondLine(RawLines.ElementAt(1)),
+            new TD1ThirdLine(RawLines.Last())
+        };
+    }
+}

--- a/MRZCodeParser/DocumentType.cs
+++ b/MRZCodeParser/DocumentType.cs
@@ -6,6 +6,7 @@ namespace MRZCodeParser
         C,
         I,
         P,
-        V
+        V,
+        ID
     }
 }

--- a/MRZCodeParser/FieldType.cs
+++ b/MRZCodeParser/FieldType.cs
@@ -6,6 +6,7 @@ namespace MRZCodeParser
     {
         DocumentType,
         CountryCode,
+        [ReplaceHelper("")]
         DocumentNumber,
         DocumentNumberCheckDigit,
         OptionalData1,

--- a/MRZCodeParser/MRZCodeParser.csproj
+++ b/MRZCodeParser/MRZCodeParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageVersion>0.4.1</PackageVersion>
         <Authors>snifter</Authors>

--- a/MRZCodeParser/MRZCodeParser.csproj
+++ b/MRZCodeParser/MRZCodeParser.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net9.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.4.1</PackageVersion>
+        <PackageVersion>0.4.2</PackageVersion>
         <Authors>snifter</Authors>
-        <AssemblyVersion>0.4.1</AssemblyVersion>
+        <AssemblyVersion>0.4.2</AssemblyVersion>
         <Title>MRZCodeParser</Title>
         <PackageProjectUrl>https://github.com/snifter/MRZCode.NET</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/snifter/MRZCode.NET/blob/master/LICENSE</PackageLicenseUrl>

--- a/MRZCodeParser/MrzCode.cs
+++ b/MRZCodeParser/MrzCode.cs
@@ -72,6 +72,7 @@ namespace MRZCodeParser
                 CodeType.TD3 => new TD3MrzCode(lines),
                 CodeType.MRVA => new MRVAMrzCode(lines),
                 CodeType.MRVB => new MRVBMrzCode(lines),
+                CodeType.TD1_LONG_DOC_NUMBER => new TD1LongDocumentMrzCode(lines),
                 _ => new UnknownMrzCode(lines)
             };
         }

--- a/MRZCodeParser/MrzLine.cs
+++ b/MRZCodeParser/MrzLine.cs
@@ -27,14 +27,14 @@ namespace MRZCodeParser
                 {
                     fields.Add(new Field(
                         FieldTypes.ElementAt(i),
-                        new ValueCleaner(match.Groups[i + 1].Value).Clean()));
+                        new ValueCleaner(match.Groups[i + 1].Value).Clean(FieldTypes.ElementAt(i))));
                 }
 
                 return new FieldsCollection(fields);
             }
         }
 
-        protected abstract string Pattern { get; }
+        protected abstract string Pattern { get;}
 
         internal abstract IEnumerable<FieldType> FieldTypes { get; }
 

--- a/MRZCodeParser/ReplaceHelper.cs
+++ b/MRZCodeParser/ReplaceHelper.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MRZCodeParser
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    internal class ReplaceHelper :Attribute
+    {
+        public string Simple { get; set; } = " ";
+        public string Double { get; set; } = ", ";
+
+        public ReplaceHelper()
+        { }
+
+        public ReplaceHelper(string simpleReplaceText)
+        {
+            Simple = simpleReplaceText;
+            Double = ", ";
+        }
+
+        public ReplaceHelper(string simpleReplaceText, string doubleReplaceText)
+        {
+            Simple = simpleReplaceText;
+            Double = doubleReplaceText;
+        }
+    }
+}

--- a/MRZCodeParser/ValueCleaner.cs
+++ b/MRZCodeParser/ValueCleaner.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
 namespace MRZCodeParser
 {
     internal class ValueCleaner
@@ -12,8 +16,20 @@ namespace MRZCodeParser
         internal string Clean()
         {
             return value.TrimEnd('<')
-                .Replace("<<", ", ")
-                .Replace("<", " ");
+                        .Replace("<<", ", ")
+                        .Replace("<", " ");
+        }
+
+        internal string Clean(FieldType f)
+        {
+            var member = typeof(FieldType).GetMember(f.ToString()).FirstOrDefault();
+            var s_replacer = member?.GetCustomAttribute<ReplaceHelper>() ?? new ReplaceHelper(" ", ", ");
+
+            var t_val = value.TrimEnd('<')
+                .Replace("<<", s_replacer.Double)
+                .Replace("<", s_replacer.Simple);
+
+            return t_val;
         }
     }
 }


### PR DESCRIPTION
Belgian identity cards have a different document id, which is shown in the first line of the TD1 version. 
Added support for this and replaced netcoreapp3.1 with net9.0.